### PR TITLE
Release/1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,6 @@ monitor:
       enable.auto.commit: "false"        # IMPORTANT: Should be set to false
       group.id: "monitor"
 
-licenses_directory": /etc/licenses       # Path to the directory where licenses are stored
+licenses_directory: /etc/licenses       # Path to the directory where licenses are stored
+organization_mode: false                # Ignore organization_uuid. Count every message as belonging to org "*"
 ```

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,6 +56,7 @@ type AppConfig struct {
 	}
 
 	LicensesDirectory string `yaml:"licenses_directory" mandatory:"true"`
+	OrganizationMode  bool   `yaml:"organization_mode"`
 }
 
 // verify checks for fields with "mandatory" struc tag set to "true" and if

--- a/cmd/counters_monitor.go
+++ b/cmd/counters_monitor.go
@@ -67,12 +67,7 @@ func CountersMonitor(config *AppConfig) {
 }
 
 // BootstrapMonitorPipeline bootstrap a RBForwarder pipeline
-func BootstrapMonitorPipeline(config *AppConfig, limitBytes int64) *rbforwarder.RBForwarder {
-	// TODO This only works for one generic UUID
-	limits := map[string]uint64{
-		"*": uint64(limitBytes),
-	}
-
+func BootstrapMonitorPipeline(config *AppConfig, limits LimitBytes) *rbforwarder.RBForwarder {
 	p, err := BootstrapRdKafkaProducer(config.Monitor.Kafka.Attributes)
 	if err != nil {
 		log.Fatal("Error creating monitor producer: " + err.Error())

--- a/cmd/counters_monitor.go
+++ b/cmd/counters_monitor.go
@@ -57,9 +57,14 @@ func CountersMonitor(config *AppConfig) {
 
 			<-time.After(remaining)
 
-			pipeline.Produce(nil, map[string]interface{}{
-				"reset_notification": true,
-			}, nil)
+			for org, bytes := range limitBytes {
+				if bytes > 0 {
+					pipeline.Produce(nil, map[string]interface{}{
+						"reset_notification": true,
+						"organization_uuid":  org,
+					}, nil)
+				}
+			}
 
 			reset <- struct{}{}
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,10 +101,8 @@ func main() {
 	sigint := make(chan os.Signal)
 	signal.Notify(sigint, os.Interrupt)
 
-	go func() {
-		<-sigint
-		close(terminate)
-	}()
+	<-sigint
+	close(terminate)
 
 	/////////////
 	// The End //

--- a/cmd/uuid_counters.go
+++ b/cmd/uuid_counters.go
@@ -129,6 +129,9 @@ func UUIDCountersPipeline(config *AppConfig) {
 					}
 
 					pipeline.Produce(event.Value, map[string]interface{}{
+						// NOTE batch_group and uuid should be the same to ensure that
+						// messages from the same organization are grouped together when
+						// they are counted.
 						"uuid":        org,
 						"batch_group": org,
 					}, nil)

--- a/cmd/uuid_counters.go
+++ b/cmd/uuid_counters.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 
 	rdkafka "github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/redBorder/events-counter/counter"
@@ -117,25 +118,20 @@ func UUIDCountersPipeline(config *AppConfig) {
 					log.Errorln(event.String())
 
 				case *rdkafka.Message:
-					isTeldat, err := CheckTeldat(event.Value)
+					isTeldat, org, err := checkMessage(event.Value)
 					if err != nil {
+						log.Warn(err)
 						continue
 					}
 
-					// TODO extract the UUID of the message instead of send generic UUID
 					if isTeldat {
-						pipeline.Produce(event.Value, map[string]interface{}{
-							"uuid":        "*",
-							"batch_group": "teldat",
-							"is_teldat":   true,
-						}, nil)
-					} else {
-						pipeline.Produce(event.Value, map[string]interface{}{
-							"uuid":        "*",
-							"batch_group": "generic",
-							"is_teldat":   false,
-						}, nil)
+						continue
 					}
+
+					pipeline.Produce(event.Value, map[string]interface{}{
+						"uuid":        org,
+						"batch_group": org,
+					}, nil)
 
 				default:
 					log.Debugln(e.String())
@@ -149,17 +145,24 @@ func UUIDCountersPipeline(config *AppConfig) {
 	}()
 }
 
-// CheckTeldat checks if the message comes from a Teldat sensor
-func CheckTeldat(data []byte) (bool, error) {
-	message := make(map[string]interface{})
-	err := json.Unmarshal(data, &message)
+func checkMessage(message []byte) (isTeldat bool, org string, err error) {
+	parsed := make(map[string]interface{})
+	err = json.Unmarshal(message, &parsed)
 	if err != nil {
-		return false, err
+		return
 	}
 
-	if _, ok := message["product_name"]; !ok {
-		return false, nil
+	if orgIf, ok := parsed["organization_uuid"]; ok {
+		org, ok = orgIf.(string)
+		if !ok {
+			err = errors.New("Field 'organization_uuid' is not string")
+			return
+		}
 	}
 
-	return true, nil
+	if _, ok := parsed["product_name"]; ok {
+		isTeldat = true
+	}
+
+	return
 }

--- a/counter/counter.go
+++ b/counter/counter.go
@@ -30,7 +30,7 @@ type Monitor struct {
 	Monitor   string `json:"monitor"`
 	Unit      string `json:"unit"`
 	Value     uint64 `json:"value"`
-	UUID      string `json:"uuid"`
+	UUID      string `json:"organization_uuid"`
 	Timestamp int64  `json:"timestamp"`
 }
 

--- a/counter/counter.go
+++ b/counter/counter.go
@@ -32,7 +32,6 @@ type Monitor struct {
 	Value     uint64 `json:"value"`
 	UUID      string `json:"uuid"`
 	Timestamp int64  `json:"timestamp"`
-	// IsTeldat  bool   `json:"is_teldat"`
 }
 
 // Config contains the configuration for a Counter
@@ -80,15 +79,6 @@ func (c *Counter) OnMessage(m *utils.Message, done utils.Done) {
 	if uuid, ok := m.Opts.Get("uuid"); ok {
 		if uuid, ok := uuid.(string); ok {
 			countData.UUID = uuid
-		}
-	}
-
-	if isTeldat, ok := m.Opts.Get("is_teldat"); ok {
-		if isTeldat, ok := isTeldat.(bool); ok {
-			if isTeldat {
-				done(m, 0, "Ignore Teldat")
-				return
-			}
 		}
 	}
 

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -87,27 +87,6 @@ func TestCounter(t *testing.T) {
 			})
 		})
 
-		Convey("When a message from a Teldat sensor is received is received", func() {
-			message := utils.NewMessage()
-			message.PushPayload([]byte(`{"message": "Lorem ipsum dolor sit amet"}`))
-			message.Opts.Set("uuid", "test_uuid")
-			message.Opts.Set("is_teldat", true)
-
-			Convey("Should not produce a count message", func() {
-				d := new(Doner)
-				d.doneCalled = make(chan *utils.Message, 1)
-				d.On("Done", mock.AnythingOfType("*utils.Message"), 0, mock.AnythingOfType("string"))
-
-				counter.OnMessage(message, d.Done)
-				result := <-d.doneCalled
-				payload, err := result.PopPayload()
-				So(err.Error(), ShouldEqual, "No payload available")
-				So(payload, ShouldBeNil)
-
-				d.AssertExpectations(t)
-			})
-		})
-
 		Convey("When a message without payload is received", func() {
 			message := utils.NewMessage()
 

--- a/monitor/messages.go
+++ b/monitor/messages.go
@@ -25,7 +25,6 @@ type Count struct {
 	Value     uint64
 	UUID      string
 	Timestamp int64
-	IsTeldat  bool
 }
 
 // Alert contains the information abot a message alerting that the

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -109,11 +109,6 @@ func (mon *CountersMonitor) OnMessage(m *utils.Message, done utils.Done) {
 		return
 	}
 
-	if count.IsTeldat {
-		done(m, 0, "Teldat sensor")
-		return
-	}
-
 	if bytes, ok = mon.db[count.UUID]; !ok {
 		m.PushPayload(createUknownUUIDMessage(count.UUID))
 		done(m, 0, "Unknown UUID: \""+count.UUID+"\"")

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -83,11 +83,10 @@ func (mon *CountersMonitor) OnMessage(m *utils.Message, done utils.Done) {
 	)
 
 	if _, ok = m.Opts.Get("reset_notification"); ok {
-		for k := range mon.db {
-			mon.db[k] = 0
-		}
+		org, _ := m.Opts.Get("organization_uuid")
+		mon.db[org.(string)] = 0
 
-		m.PushPayload(createResetNotificationMessage())
+		m.PushPayload(createResetNotificationMessage(org.(string)))
 		mon.Log.Debugf("Sending reset notification")
 		done(m, 0, "Reset notification")
 		return

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -99,7 +99,7 @@ func TestMonitor(t *testing.T) {
 					"monitor":"organization_received_bytes",
 					"unit":"bytes",
 					"value":10,
-					"uuid":"unknown",
+					"organization_uuid":"unknown",
 					"timestamp":643975200
 				}
 			`))
@@ -107,7 +107,8 @@ func TestMonitor(t *testing.T) {
 			Convey("Should alert the unknown UUID", func() {
 				d := new(Doner)
 				d.doneCalled = make(chan *utils.Message, 1)
-				d.On("Done", mock.AnythingOfType("*utils.Message"), 0, "Unknown UUID: \"unknown\"")
+				d.On("Done", mock.AnythingOfType(
+					"*utils.Message"), 0, mock.AnythingOfType("string"))
 
 				monitor.OnMessage(message, d.Done)
 				result := <-d.doneCalled
@@ -232,7 +233,7 @@ func TestMonitorReset(t *testing.T) {
 					"monitor":"organization_received_bytes",
 					"unit":"bytes",
 					"value":51,
-					"uuid":"my_uuid",
+					"organization_uuid":"my_uuid",
 					"timestamp":643975200
 					}`))
 
@@ -255,7 +256,7 @@ func TestMonitorReset(t *testing.T) {
 					"monitor":"organization_received_bytes",
 					"unit":"bytes",
 					"value":51,
-					"uuid":"my_uuid",
+					"organization_uuid":"my_uuid",
 					"timestamp":643975200
 					}`))
 
@@ -317,7 +318,7 @@ func TestMonitorReset(t *testing.T) {
 						"monitor":"organization_received_bytes",
 						"unit":"bytes",
 						"value":51,
-						"uuid":"my_uuid",
+						"organization_uuid":"my_uuid",
 						"timestamp":643975200
 						}`))
 

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -288,6 +288,7 @@ func TestMonitorReset(t *testing.T) {
 			Convey("Should send a reset notification", func() {
 				message := utils.NewMessage()
 				message.Opts.Set("reset_notification", nil)
+				message.Opts.Set("organization_uuid", "my_uuid")
 
 				d := new(Doner)
 				d.doneCalled = make(chan *utils.Message, 1)
@@ -304,6 +305,7 @@ func TestMonitorReset(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(response["monitor"], ShouldEqual, "alert")
 				So(response["type"], ShouldEqual, "counters_reset")
+				So(response["uuid"], ShouldEqual, "my_uuid")
 
 				bytes := monitor.(*CountersMonitor).db["my_uuid"]
 				So(bytes, ShouldEqual, 0)

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -125,33 +125,6 @@ func TestMonitor(t *testing.T) {
 			})
 		})
 
-		Convey("When a message is received from a Teldat sensor", func() {
-			message := utils.NewMessage()
-			message.PushPayload([]byte(`
-				{
-					"monitor":"organization_received_bytes",
-					"unit":"bytes",
-					"value":10,
-					"uuid":"*",
-					"timestamp":643975200,
-					"is_teldat":true
-				}
-			`))
-
-			Convey("Should ignore the message", func() {
-				d := new(Doner)
-				d.doneCalled = make(chan *utils.Message, 1)
-				d.On("Done", mock.AnythingOfType("*utils.Message"), 0, mock.AnythingOfType("string"))
-
-				monitor.OnMessage(message, d.Done)
-				result := <-d.doneCalled
-				_, err := result.PopPayload()
-				So(err, ShouldNotBeNil)
-
-				d.AssertExpectations(t)
-			})
-		})
-
 		Convey("When a message with an unknown monitor is received", func() {
 			message := utils.NewMessage()
 			message.PushPayload([]byte(`

--- a/monitor/utils.go
+++ b/monitor/utils.go
@@ -151,7 +151,7 @@ func ParseCount(data []byte) *Count {
 		return nil
 	}
 
-	if uuid, ok := msg["uuid"]; ok {
+	if uuid, ok := msg["organization_uuid"]; ok {
 		if count.UUID, ok = uuid.(string); !ok {
 			return nil
 		}

--- a/monitor/utils.go
+++ b/monitor/utils.go
@@ -131,7 +131,7 @@ func IntervalEndsAt(period, offset int64, now time.Time) time.Time {
 	return time.Unix(intervalEnd, 0)
 }
 
-// ParseCount gets a json as a map and returns a struc with the values
+// ParseCount gets a json as a map and returns a struct with the values
 func ParseCount(data []byte) *Count {
 	var ok bool
 
@@ -171,11 +171,6 @@ func ParseCount(data []byte) *Count {
 		}
 
 		count.Timestamp = int64(floatTimestamp)
-	}
-	if isTeldat, ok := msg["is_teldat"]; ok {
-		if count.IsTeldat, ok = isTeldat.(bool); !ok {
-			return nil
-		}
 	}
 
 	return count

--- a/monitor/utils.go
+++ b/monitor/utils.go
@@ -70,12 +70,13 @@ func createUknownUUIDMessage(uuid string) []byte {
 
 // createUknownUUIDMessage builds a JSON message alerting that an UUID does
 // not exists on the internal database.
-func createResetNotificationMessage() []byte {
+func createResetNotificationMessage(org string) []byte {
 	var data []byte
 
 	alert := &Alert{
-		Monitor:   "alert",
 		Timestamp: time.Now().Unix(),
+		Monitor:   "alert",
+		UUID:      org,
 		Type:      "counters_reset",
 	}
 


### PR DESCRIPTION
### Changelog
- Read organization licenses (Closes #14)
- Count message per organization (Closes #16)
- Configuration for choosing between organization mode and normal mode (Closes #15)
- Reset signal should not be sent when no licenses are available (Fixes #20)
- Rename "uuid" field (Fixes #18)