### PR TITLE
Send a "licence_expired" notification

### DIFF
--- a/cmd/license.go
+++ b/cmd/license.go
@@ -38,8 +38,26 @@ import (
 // PubKey should be set on compile time
 var PubKey string
 
+type licenseStatus struct {
+	OrganizationUUID string
+	Amount           uint64
+	Expired          bool
+}
+
 // LimitBytes is a map containing the max bytes for each organization
-type LimitBytes map[string]uint64
+type LimitBytes map[string]*licenseStatus
+
+func (l LimitBytes) getOrganizationLimits() map[string]uint64 {
+	total := make(map[string]uint64)
+
+	for _, v := range l {
+		if !v.Expired {
+			total[v.OrganizationUUID] += v.Amount
+		}
+	}
+
+	return total
+}
 
 // License contains information about the limits of bytes that an organization
 // can send.
@@ -55,7 +73,8 @@ type License struct {
 // LoadLicenses reads a redBorder license from a file and returns a License
 // struct holding the decoded information.
 func LoadLicenses(config *AppConfig) (LimitBytes, error) {
-	var licenses []License
+	limits := make(LimitBytes)
+
 	log := log.WithField("prefix", "license")
 
 	files, err := ioutil.ReadDir(config.LicensesDirectory)
@@ -93,45 +112,34 @@ func LoadLicenses(config *AppConfig) (LimitBytes, error) {
 			return nil, err
 		}
 
+		limits[license.UUID] = &licenseStatus{}
+
 		expires := time.Unix(license.ExpireAt, 0)
 		if expires.Before(time.Now()) {
 			log.Warnf("License %s has expired", license.UUID)
+			limits[license.UUID].Expired = true
 			continue
 		}
 
 		log.Infoln(FormatLicense(license))
 
-		licenses = append(licenses, *license)
-	}
-
-	limits := make(LimitBytes)
-	if !config.OrganizationMode {
-		var totalBytes uint64
-		for _, license := range licenses {
-			if license.Organization != "" {
-				log.Warnf("Ignoring license WITH organization %s", license.UUID)
-				continue
-			}
-
-			totalBytes += license.LimitBytes
-		}
-
-		limits["*"] = totalBytes
-	} else {
-		for _, license := range licenses {
+		if config.OrganizationMode {
 			if license.Organization == "" {
 				log.Warnf("Ignoring license WITH NO organization %s", license.UUID)
 				continue
 			}
 
-			limits[license.Organization] = limits[license.Organization] + license.LimitBytes
-		}
-	}
+			limits[license.UUID].Amount += license.LimitBytes
+			limits[license.UUID].OrganizationUUID = license.Organization
+		} else {
+			if license.Organization != "" {
+				log.Warnf("Ignoring license WITH organization %s", license.UUID)
+				continue
+			}
 
-	for k, v := range limits {
-		log.
-			WithField("Total bytes", v).
-			Infof("Organization %s", k)
+			limits[license.UUID].Amount += license.LimitBytes
+			limits[license.UUID].OrganizationUUID = "*"
+		}
 	}
 
 	return limits, nil

--- a/monitor/messages.go
+++ b/monitor/messages.go
@@ -34,6 +34,6 @@ type Alert struct {
 	Type         string `json:"type"`
 	UUID         string `json:"uuid,omitempty"`
 	CurrentBytes uint64 `json:"current_bytes,omitempty"`
-	Limit        uint64 `json:"limit"`
+	Limit        uint64 `json:"limit,omitempty"`
 	Timestamp    int64  `json:"timestamp"`
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -92,6 +92,15 @@ func (mon *CountersMonitor) OnMessage(m *utils.Message, done utils.Done) {
 		return
 	}
 
+	if _, ok = m.Opts.Get("expiry_notification"); ok {
+		uuid, _ := m.Opts.Get("license_uuid")
+
+		m.PushPayload(createExpiryNotificationMessage(uuid.(string)))
+		mon.Log.Debugf("Sending expiry notification")
+		done(m, 0, "Expiry notification")
+		return
+	}
+
 	if payload, err = m.PopPayload(); err != nil {
 		done(m, 0, "No payload to produce")
 		return

--- a/monitor/utils.go
+++ b/monitor/utils.go
@@ -84,6 +84,22 @@ func createResetNotificationMessage(org string) []byte {
 	return data
 }
 
+// createUknownUUIDMessage builds a JSON message alerting that an UUID does
+// not exists on the internal database.
+func createExpiryNotificationMessage(uuid string) []byte {
+	var data []byte
+
+	alert := &Alert{
+		Timestamp: time.Now().Unix(),
+		Monitor:   "alert",
+		UUID:      uuid,
+		Type:      "license_expired",
+	}
+
+	data, _ = json.Marshal(alert)
+	return data
+}
+
 // checkTimestamp is used to discard old timestamps (messages from previous
 // period).
 //


### PR DESCRIPTION
A notification is sent when `events` counters detect that a license has expired.

Notification example:

```json
{
  "monitor": "alert",
  "type": "license_expired",
  "uuid": "db630d36-ed33-4aee-bb8c-03115ed89379",
  "timestamp": 1498041163
}
```